### PR TITLE
Add Local Repo to GitHub Desktop Edits

### DIFF
--- a/content/desktop/adding-and-cloning-repositories/adding-a-repository-from-your-local-computer-to-github-desktop.md
+++ b/content/desktop/adding-and-cloning-repositories/adding-a-repository-from-your-local-computer-to-github-desktop.md
@@ -21,7 +21,7 @@ shortTitle: Add a repository
    ![Screenshot of the menu bar on a Mac. The "File" dropdown menu is open, and an option labeled "Add Local Repository" is highlighted with an orange outline.](/assets/images/help/desktop/add-local-repository-mac.png)
 2. In the "Add Local Repository" window, click **Choose...**, then use the Finder window to navigate to the local repository you want to add.
    ![Screenshot of the "Add Local Repository" window. Next to the "repository path" field, a button, labeled "Choose", is highlighted with an orange outline.](/assets/images/help/desktop/add-repo-choose-button-mac.png)
-3. When you have chosen the local repository, in the "Add Local Repository" window, click **Add Repository**.
+3. When you have chosen the local repository, in the "Add Local Repository" window, click **Add Repository**. ***Reminder: to add an existing project to Github using Github Desktop, you will need to follow different instructions. These instructions are for local repositories.***
 
 {% endmac %}
 
@@ -31,6 +31,6 @@ shortTitle: Add a repository
    ![Screenshot of the menu bar on Windows. The "File" dropdown menu is open, and an option labeled "Add local repository" is highlighted with an orange outline.](/assets/images/help/desktop/add-local-repository-windows.png)
 2. In the "Add local repository" window, click **Choose...**, then use Windows Explorer to navigate to the local repository you want to add.
    ![Screenshot of the "Add local repository" window. Next to the "repository path" field, a button, labeled "Choose", is highlighted with an orange outline.](/assets/images/help/desktop/add-repo-choose-button-mac.png)
-3. Click **Add repository**.
+3. Click **Add repository**. ***Reminder: to add an existing project to Github using Github Desktop, you will need to follow different instructions. These instructions are for local repositories.***
 
 {% endwindows %}

--- a/content/desktop/adding-and-cloning-repositories/adding-a-repository-from-your-local-computer-to-github-desktop.md
+++ b/content/desktop/adding-and-cloning-repositories/adding-a-repository-from-your-local-computer-to-github-desktop.md
@@ -11,26 +11,26 @@ shortTitle: Add a repository
 ---
 {% tip %}
 
-**Tip:** You can add a Git repository from your local computer to GitHub Desktop by dragging the folder onto the {% data variables.product.prodname_desktop %} window. If you drag multiple Git folders into {% data variables.product.prodname_desktop %} at the same time, each folder will be added as a separate Git repository.
+**Tip for Advanced Users:** You can add a Git repository from your local computer to GitHub Desktop by dragging the folder onto the {% data variables.product.prodname_desktop %} window. If you drag multiple Git folders into {% data variables.product.prodname_desktop %} at the same time, each folder will be added as a separate Git repository.
 
 {% endtip %}
 
 {% mac %}
 
-1. In the menu bar, select **File**, then click **Add Local Repository**.
+1. Locate the menu bar in the top left corner of your screen. Select **File**. A drop down menu will appear, then click **Add Local Repository**.
    ![Screenshot of the menu bar on a Mac. The "File" dropdown menu is open, and an option labeled "Add Local Repository" is highlighted with an orange outline.](/assets/images/help/desktop/add-local-repository-mac.png)
-1. In the "Add Local Repository" window, click **Choose...**, then use the Finder window to navigate to the local repository you want to add.
+2. In the "Add Local Repository" window, click **Choose...**, then use the Finder window to navigate to the local repository you want to add.
    ![Screenshot of the "Add Local Repository" window. Next to the "repository path" field, a button, labeled "Choose", is highlighted with an orange outline.](/assets/images/help/desktop/add-repo-choose-button-mac.png)
-1. When you have chosen the local repository, in the "Add Local Repository" window, click **Add Repository**.
+3. When you have chosen the local repository, in the "Add Local Repository" window, click **Add Repository**.
 
 {% endmac %}
 
 {% windows %}
 
-1. In the menu bar, select **File**, then click **Add local repository**.
+1. Locate the menu bar for GitHub Desktop on your screen. Select **File**. A drop down menu will appear, then click **Add local repository**.
    ![Screenshot of the menu bar on Windows. The "File" dropdown menu is open, and an option labeled "Add local repository" is highlighted with an orange outline.](/assets/images/help/desktop/add-local-repository-windows.png)
-1. In the "Add local repository" window, click **Choose...**, then use Windows Explorer to navigate to the local repository you want to add.
+2. In the "Add local repository" window, click **Choose...**, then use Windows Explorer to navigate to the local repository you want to add.
    ![Screenshot of the "Add local repository" window. Next to the "repository path" field, a button, labeled "Choose", is highlighted with an orange outline.](/assets/images/help/desktop/add-repo-choose-button-mac.png)
-1. Click **Add repository**.
+3. Click **Add repository**.
 
 {% endwindows %}


### PR DESCRIPTION
## "Add Repo From Your Local Computer to GitHub Desktop" Suggested Edits

## Staging

### Writing for intended audience

- The tip paragraph at the top is useful information but not necessarily for a novice user. **Renamed to "Tip for Advanced Users"**


## Coaching

### Writing for intended audience

- The image for step 1 under Mac and Windows users shows File already selected and then highlights the Add Local Repository. **Added step for locating File at top of screen and then describe the drop down menu before clicking Add Local Repository.**


## Alerting

### Focus on users' goals

- Currently, there are no warnings on this page and examples are shown as the screenshots. **Added a reminder at the end of the instructions that clearly states these steps are for local repos and not existing.**